### PR TITLE
fix: don't clear required status checks

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -145,7 +145,6 @@ for repository in "${REPOSITORIES[@]}"; do
         '{
             required_status_checks:{
                 strict: $requiredStatusChecks,
-                checks: []
             },
             enforce_admins:$enforceAdmins,
             required_pull_request_reviews:{


### PR DESCRIPTION
This fixes an issue where the checks required for a PR to be merged is set to an empty array. See https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#update-branch-protection